### PR TITLE
Upgrade XCode version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: swift
-osx_image: xcode11.1
+osx_image: xcode11.3
 before_install:
   - brew install python
   - pip install requests


### PR DESCRIPTION
Currently, Travis will not spin up a CI box with the 11.1 setting. I believe this is because they have no machines with that version.

Bumping the version to test.