### PR TITLE
Update Swift to Use New Uploader

### DIFF
--- a/.github/workflows/swift_macos-10.15.yml
+++ b/.github/workflows/swift_macos-10.15.yml
@@ -1,11 +1,11 @@
 name: Github Actions Swift Standard
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+on: [push]
+  # push:
+  #   branches:
+  #     - master
+  # pull_request:
+  #   branches:
+  #     - master
 jobs:
   test-and-standard-upload:
     runs-on: macos-10.15
@@ -33,15 +33,17 @@ jobs:
         pathCoverage=Build/Build/ProfileData/${directory}/Coverage.profdata
         cd ../../../../
         xcrun llvm-cov export -format="lcov" -instr-profile $pathCoverage Build/Build/Products/Debug-iphonesimulator/standard-swift.app/standard-swift > info.lcov
-        bash <(curl https://codecov.io/bash)
+        curl -Os https://uploader.codecov.io/latest/linux/codecov
+        chmod +x codecov
+        ./codecov -t ${CODECOV_TOKEN}
         python request.py
-    - name: Upstream to Standards
-      env:
-        GH_TOKEN: ${{ secrets.GH_TOKEN }}
-        COVERAGE_SOURCE_FILE: ${{ secrets.COVERAGE_SOURCE_FILE }}
-      if: ${{ github.event_name == 'push'}}
-      run: |
-        wget --header "Authorization: token ${GH_TOKEN}" \
-        --header "Accept: application/vnd.github.v3.raw" \
-        https://api.github.com/repos/codecov/standards/contents/upstream.sh
-        bash upstream.sh
+    # - name: Upstream to Standards
+    #   env:
+    #     GH_TOKEN: ${{ secrets.GH_TOKEN }}
+    #     COVERAGE_SOURCE_FILE: ${{ secrets.COVERAGE_SOURCE_FILE }}
+    #   if: ${{ github.event_name == 'push'}}
+    #   run: |
+    #     wget --header "Authorization: token ${GH_TOKEN}" \
+    #     --header "Accept: application/vnd.github.v3.raw" \
+    #     https://api.github.com/repos/codecov/standards/contents/upstream.sh
+    #     bash upstream.sh

--- a/.github/workflows/swift_macos-10.15.yml
+++ b/.github/workflows/swift_macos-10.15.yml
@@ -33,7 +33,7 @@ jobs:
         pathCoverage=Build/Build/ProfileData/${directory}/Coverage.profdata
         cd ../../../../
         xcrun llvm-cov export -format="lcov" -instr-profile $pathCoverage Build/Build/Products/Debug-iphonesimulator/standard-swift.app/standard-swift > info.lcov
-        curl -Os https://uploader.codecov.io/latest/linux/codecov
+        curl -Os https://uploader.codecov.io/latest/macos/codecov
         chmod +x codecov
         ./codecov -t ${CODECOV_TOKEN}
         python request.py

--- a/.github/workflows/swift_macos-10.15.yml
+++ b/.github/workflows/swift_macos-10.15.yml
@@ -1,11 +1,11 @@
 name: Github Actions Swift Standard
-on: [push]
-  # push:
-  #   branches:
-  #     - master
-  # pull_request:
-  #   branches:
-  #     - master
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 jobs:
   test-and-standard-upload:
     runs-on: macos-10.15
@@ -29,7 +29,7 @@ jobs:
         xcodebuild -scheme standard-swift -sdk iphonesimulator -derivedDataPath Build/ -destination 'platform=iOS Simulator,name=iPhone 11,OS=14.4' -enableCodeCoverage YES clean build test
         cd Build/Build/ProfileData
         cd $(ls -d */|head -n 1)
-        directory=${PWD##*/} 
+        directory=${PWD##*/}
         pathCoverage=Build/Build/ProfileData/${directory}/Coverage.profdata
         cd ../../../../
         xcrun llvm-cov export -format="lcov" -instr-profile $pathCoverage Build/Build/Products/Debug-iphonesimulator/standard-swift.app/standard-swift > info.lcov
@@ -37,13 +37,13 @@ jobs:
         chmod +x codecov
         ./codecov -t ${CODECOV_TOKEN}
         python request.py
-    # - name: Upstream to Standards
-    #   env:
-    #     GH_TOKEN: ${{ secrets.GH_TOKEN }}
-    #     COVERAGE_SOURCE_FILE: ${{ secrets.COVERAGE_SOURCE_FILE }}
-    #   if: ${{ github.event_name == 'push'}}
-    #   run: |
-    #     wget --header "Authorization: token ${GH_TOKEN}" \
-    #     --header "Accept: application/vnd.github.v3.raw" \
-    #     https://api.github.com/repos/codecov/standards/contents/upstream.sh
-    #     bash upstream.sh
+    - name: Upstream to Standards
+      env:
+        GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        COVERAGE_SOURCE_FILE: ${{ secrets.COVERAGE_SOURCE_FILE }}
+      if: ${{ github.event_name == 'push'}}
+      run: |
+        wget --header "Authorization: token ${GH_TOKEN}" \
+        --header "Accept: application/vnd.github.v3.raw" \
+        https://api.github.com/repos/codecov/standards/contents/upstream.sh
+        bash upstream.sh

--- a/request.py
+++ b/request.py
@@ -20,7 +20,7 @@ commit_data = all_data['commits'][0]
 coverage_percentage = commit_data['totals']['c']
 
 print("Ensuring coverage percentage is accurate...")
-#result should return 82.35294  as its coverage metric
+#result should return 86.66667 as its coverage metric
 if(coverage_percentage == os.environ['CORRECT_COVERAGE']): 
     print("Success! Codecov's API returned the correct coverage percentage, "+ os.environ['CORRECT_COVERAGE'])
     exit(0)


### PR DESCRIPTION
This PR is to update the Swift Standard to use the new uploader. It was discovered that updating the uploader in this repo had effects on the coverage it yields, hence this ticket.

As part of this effort, I would need someone with right permissions to change the `EXPECTED_COVERAGE` env variable for this repo to `86.66667` as that is the new expected coverage, allowing the GHA to pass successfully as it should.